### PR TITLE
Update (spacing, origin) target volumes

### DIFF
--- a/tool/Code/utilities/conform.py
+++ b/tool/Code/utilities/conform.py
@@ -143,9 +143,15 @@ def conform(img,flags,order,save_path,mod,axial=False):
         save = True
 
     img_header.set_data_shape(img_arr.shape)
-    img_header.set_zooms(izoom)
+    img_header.set_zooms(i_zoom)
 
-    new_img = nib.Nifti1Image(img_arr, img.affine, img_header)
+    affine = img_header.get_qform()
+    affine[0][3] += ((flags['imgSize'][0] - ishape[0]) / 2 * i_zoom[0])
+    affine[1][3] -= ((flags['imgSize'][1] - ishape[1]) / 2 * i_zoom[1])
+    affine[2][3] -= ((flags['imgSize'][2] - ishape[2]) / 2 * i_zoom[2])
+    img_header.set_qform(affine)
+
+    new_img = nib.Nifti1Image(img_arr, affine, img_header)
     #save images if modified
 
     if save:


### PR DESCRIPTION
In order to overlay the original volume with the predicted segmentations, both the FatSegNet default spacing (1.9531, 1.9531, 5.0) and the translation of the origin (due to cropping/padding) need to be added to the target volume header.

**Before:**
![Before](https://user-images.githubusercontent.com/9911296/75246802-cfd6db00-57d0-11ea-9f0f-5515fafccb52.png)

**After:**
![After](https://user-images.githubusercontent.com/9911296/75245212-8e90fc00-57cd-11ea-91f0-55720f8dc422.png)